### PR TITLE
fix: singularity picard option conflict

### DIFF
--- a/configs/singularity.config
+++ b/configs/singularity.config
@@ -3,5 +3,6 @@
  ********************/
 
 env {
-  picard_app = 'java -jar /picard/picard.jar'
+//  picard_app = 'java -jar /picard/picard.jar'
+  picard_app = params.picard_app ? " $params.picard_app " : 'java -jar /picard/picard.jar'
 }


### PR DESCRIPTION
users want to be able to specify the java temp directory, to avoid running out of space. Fixed so the singularity picard_app didn't overwrite their java options.